### PR TITLE
Run JVMs started by JMH with a fixed heap size

### DIFF
--- a/src/main/scala/Benchmarks.scala
+++ b/src/main/scala/Benchmarks.scala
@@ -32,7 +32,7 @@ object Bench {
     val libs = System.getenv("BOOTSTRAP_APPEND")
 
     val opts = new OptionsBuilder()
-               .jvmArgsPrepend(s"-Xbootclasspath/a:$libs")
+               .jvmArgsPrepend(s"-Xbootclasspath/a:$libs", "-Xms2G", "-Xmx2G")
                .mode(Mode.AverageTime)
                .timeUnit(TimeUnit.MILLISECONDS)
                .warmupIterations(warmup)


### PR DESCRIPTION
This matches what http://github.com/scala/compiler-benchmark does and
should help reduce the variance in the data points.

Note: Before merging this, it would be good to check its effect on the machine we use for benchmarks, to make sure it doesn't affect the results too much.